### PR TITLE
Add iproute2 to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        python-software-properties \
        software-properties-common \
-       rsyslog systemd systemd-cron sudo \
+       rsyslog systemd systemd-cron sudo iproute2 \
     && rm -Rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean


### PR DESCRIPTION
Enables the `ansible_default_ipv4` variable to be populated
Closes issue #5

Current behaviour:
```
root@c4c60066e036:/# ansible localhost -m setup | grep ansible_default_ipv4
root@c4c60066e036:/#
```

And if you install `iproute2`:
```
root@c4c60066e036:/# ansible localhost -m setup | grep ansible_default_ipv4 -A 11
        "ansible_default_ipv4": {
            "address": "172.17.0.2",
            "alias": "eth0",
            "broadcast": "172.17.255.255",
            "gateway": "172.17.0.1",
            "interface": "eth0",
            "macaddress": "02:42:ac:11:00:02",
            "mtu": 1500,
            "netmask": "255.255.0.0",
            "network": "172.17.0.0",
            "type": "ether"
        },
```