### PR TITLE
Disabling getty which otherwise eat 100% cpu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,18 @@ RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin
 RUN mkdir -p /etc/ansible
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 
+# Disable getty services, which otherwise will consume 100% CPU
+# There are two simple solutions to this:
+#
+# RUN cp /bin/true /sbin/agetty
+#
+# or:
+RUN ln -s /dev/null /etc/systemd/system/getty@tty1.service \
+    && ln -s /dev/null /etc/systemd/system/getty@tty2.service \
+    && ln -s /dev/null /etc/systemd/system/getty@tty3.service \
+    && ln -s /dev/null /etc/systemd/system/getty@tty4.service \
+    && ln -s /dev/null /etc/systemd/system/getty@tty5.service \
+    && ln -s /dev/null /etc/systemd/system/getty@tty6.service
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
I recently started using your container images for molecule testing. It works really well, but I ran into issues with Ubuntu 16.04, where our tests timed out (other distros go through without any problems).

I identified mgetty to be the issue:

![image](https://user-images.githubusercontent.com/2961018/111458025-3bac1e80-8719-11eb-9e0f-ecbbb258a34a.png)

My workaround is to "mute" the tty devices by creating symlinks to `/dev/null` (which is the same as a `systemctl mute getty@tty2.service`.

Example:

Before disabling the getty service (containers at idle):

```
$ docker stats

CONTAINER ID   NAME             CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O     PIDS
d7081771d104   postgresql-11    101.24%   101.2MiB / 7.778GiB   1.27%     19.9MB / 286kB   0B / 19.3MB   19
cb107790300a   postgresql-10    302.33%   99.04MiB / 7.778GiB   1.24%     19.9MB / 241kB   0B / 19.3MB   20
4fc010117a67   postgresql-9_6   194.97%   124.7MiB / 7.778GiB   1.57%     19.9MB / 269kB   0B / 19.3MB   21
```

After applying this patch:

```
$ docker stats

CONTAINER ID   NAME             CPU %     MEM USAGE / LIMIT     MEM %     NET I/O        BLOCK I/O     PIDS
8822b742a2d6   postgresql-9_6   0.05%     38.68MiB / 7.778GiB   0.49%     20MB / 234kB   0B / 21.9MB   10
6f74a65ee872   postgresql-10    0.05%     38.75MiB / 7.778GiB   0.49%     20MB / 254kB   0B / 21.9MB   10
7d430c7b3e33   postgresql-11    0.06%     38.8MiB / 7.778GiB    0.49%     20MB / 262kB   0B / 21.9MB   10
```